### PR TITLE
Option to enable QCC flashing; disable file extension check

### DIFF
--- a/app/src/main/java/me/andreww7985/connectplus/dfu/DfuModel.kt
+++ b/app/src/main/java/me/andreww7985/connectplus/dfu/DfuModel.kt
@@ -68,10 +68,10 @@ class DfuModel(val speaker: SpeakerModel) : BaseModel {
                 return@coroutineScope
             }
 
-            if (!filename.lowercase().endsWith(".dfu")) {
-                wrongFileEvent.fire()
-                return@coroutineScope
-            }
+//            if (!filename.lowercase().endsWith(".dfu")) {
+//                wrongFileEvent.fire()
+//                return@coroutineScope
+//            }
 
             state = State.LOADING_FILE
             dfuModel.filename = filename

--- a/app/src/main/java/me/andreww7985/connectplus/dfu/DfuModel.kt
+++ b/app/src/main/java/me/andreww7985/connectplus/dfu/DfuModel.kt
@@ -68,10 +68,10 @@ class DfuModel(val speaker: SpeakerModel) : BaseModel {
                 return@coroutineScope
             }
 
-//            if (!filename.lowercase().endsWith(".dfu")) {
-//                wrongFileEvent.fire()
-//                return@coroutineScope
-//            }
+            if (!(filename.lowercase().endsWith(".dfu") || filename.lowercase().endsWith(".bin"))) {
+                wrongFileEvent.fire()
+                return@coroutineScope
+            }
 
             state = State.LOADING_FILE
             dfuModel.filename = filename

--- a/app/src/main/java/me/andreww7985/connectplus/ui/activities/MainActivity.kt
+++ b/app/src/main/java/me/andreww7985/connectplus/ui/activities/MainActivity.kt
@@ -60,7 +60,7 @@ class MainActivity : AppCompatActivity() {
 
         val enableQCCFlash = App.sharedPreferences.getBoolean("enable_qcc_flash", true)
 
-        /* Only show DFU flash menu on known supported CSR models. */
+        /* Only show DFU flash menu on known supported CSR models or if QCC flashing is enabled. */
         if ((speaker.hardware.platform == HwPlatform.QCC && !enableQCCFlash)
             || speaker.hardware.platform == HwPlatform.VIMICRO
             || speaker.hardware.platform == HwPlatform.UNKNOWN) {

--- a/app/src/main/java/me/andreww7985/connectplus/ui/activities/MainActivity.kt
+++ b/app/src/main/java/me/andreww7985/connectplus/ui/activities/MainActivity.kt
@@ -58,8 +58,12 @@ class MainActivity : AppCompatActivity() {
 
         val speaker = SpeakerManager.selectedSpeaker!!
 
+        val enableQCCFlash = App.sharedPreferences.getBoolean("enable_qcc_flash", true)
+
         /* Only show DFU flash menu on known supported CSR models. */
-        if (speaker.hardware.platform != HwPlatform.CSR) {
+        if ((speaker.hardware.platform == HwPlatform.QCC && !enableQCCFlash)
+            || speaker.hardware.platform == HwPlatform.VIMICRO
+            || speaker.hardware.platform == HwPlatform.UNKNOWN) {
             binding.navMenu.menu.removeItem(R.id.nav_flash_dfu)
         }
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -25,6 +25,8 @@
     <string name="dfu_state_error">Что-то пошло не так. Скорее всего, колонка отказалась от файла прошивки. Проверьте, правильный ли вы выбрали файл и не поврежден ли он. Колонка автоматически перезагрузится в обычный режим. Приложение можно закрыть.</string>
     <string name="settings_send_speaker_data_title">Отправлять данные о колонке</string>
     <string name="settings_send_speaker_data_summary">Отправляются модель колонки, цвет и версия прошивки</string>
+    <string name="settings_enable_qcc_flash_title">Увімкнути експериментальне спалахування QCC</string>
+    <string name="settings_enable_qcc_flash_summary">НЕПЕРЕВІРЕНО! Перезапустите приложение, чтобы применить изменения.</string>
     <string name="settings_send_app_data_title">Отправлять данные об использовании приложения</string>
     <string name="settings_send_app_data_summary">Используются Google Crashlytics и Google Analytics. Перезапустите приложение, чтобы применить изменения.</string>
     <string name="setting_privacy">"Конфиденциальность "</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -25,8 +25,8 @@
     <string name="dfu_state_error">Что-то пошло не так. Скорее всего, колонка отказалась от файла прошивки. Проверьте, правильный ли вы выбрали файл и не поврежден ли он. Колонка автоматически перезагрузится в обычный режим. Приложение можно закрыть.</string>
     <string name="settings_send_speaker_data_title">Отправлять данные о колонке</string>
     <string name="settings_send_speaker_data_summary">Отправляются модель колонки, цвет и версия прошивки</string>
-    <string name="settings_enable_qcc_flash_title">Увімкнути експериментальне спалахування QCC</string>
-    <string name="settings_enable_qcc_flash_summary">НЕПЕРЕВІРЕНО! Перезапустите приложение, чтобы применить изменения.</string>
+    <string name="settings_enable_qcc_flash_title">Разрешить прошивку QCC колонок</string>
+    <string name="settings_enable_qcc_flash_summary">НЕ ИСПЫТАНО! Перезапустите приложение, чтобы применить изменения.</string>
     <string name="settings_send_app_data_title">Отправлять данные об использовании приложения</string>
     <string name="settings_send_app_data_summary">Используются Google Crashlytics и Google Analytics. Перезапустите приложение, чтобы применить изменения.</string>
     <string name="setting_privacy">"Конфиденциальность "</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -33,6 +33,8 @@
     <string name="setting_privacy">Конфіденційність</string>
     <string name="settings_send_speaker_data_title">Надсилати дані про колонку</string>
     <string name="settings_send_speaker_data_summary">Надсилаються дані про модель, колір та версію ПЗ.</string>
+    <string name="settings_enable_qcc_flash_title">Включить экспериментальную прошивку QCC</string>
+    <string name="settings_enable_qcc_flash_summary">НЕ ИСПЫТАНО! Перезапустіть додаток щоб застосувати зміни.</string>
     <string name="settings_send_app_data_summary">Використовуються Google Crashlytics та Google Analytics. Перезапустіть додаток щоб застосувати зміни.</string>
     <string name="settings_send_app_data_title">Надсилати дані про використання додатку</string>
     <string name="dfu_button_flash">Прошити</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -33,8 +33,8 @@
     <string name="setting_privacy">Конфіденційність</string>
     <string name="settings_send_speaker_data_title">Надсилати дані про колонку</string>
     <string name="settings_send_speaker_data_summary">Надсилаються дані про модель, колір та версію ПЗ.</string>
-    <string name="settings_enable_qcc_flash_title">Включить экспериментальную прошивку QCC</string>
-    <string name="settings_enable_qcc_flash_summary">НЕ ИСПЫТАНО! Перезапустіть додаток щоб застосувати зміни.</string>
+    <string name="settings_enable_qcc_flash_title">Дозволити прошивати QCC колонки</string>
+    <string name="settings_enable_qcc_flash_summary">НЕ ПЕРЕВІРЕНО! Перезапустіть додаток щоб застосувати зміни.</string>
     <string name="settings_send_app_data_summary">Використовуються Google Crashlytics та Google Analytics. Перезапустіть додаток щоб застосувати зміни.</string>
     <string name="settings_send_app_data_title">Надсилати дані про використання додатку</string>
     <string name="dfu_button_flash">Прошити</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,8 @@
     <string name="setting_privacy">Privacy</string>
     <string name="settings_send_speaker_data_title">Send speaker data</string>
     <string name="settings_send_speaker_data_summary">Sends speaker model, color and firmware version</string>
+    <string name="settings_enable_qcc_flash_title">Enable experimental QCC flashing</string>
+    <string name="settings_enable_qcc_flash_summary">UNTESTED! Restart app to apply changes.</string>
     <string name="settings_send_app_data_summary">Uses Google Crashlytics and Google Analytics. Restart app to apply changes.</string>
     <string name="settings_send_app_data_title">Send app usage data</string>
     <string name="dfu_button_flash">Flash</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -7,6 +7,11 @@
         android:title="@string/settings_dark_theme_title"
         android:defaultValue="SYSTEM" />
 
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="enable_qcc_flash"
+        android:summary="@string/settings_enable_qcc_flash_summary"
+        android:title="@string/settings_enable_qcc_flash_title" />
     <PreferenceCategory android:title="@string/setting_privacy">
         <CheckBoxPreference
             android:defaultValue="true"


### PR DESCRIPTION
Disabling file extension check is necessary as QCC firmware files for the Xtreme 2 are all `.bin`.
Also, as it stands, QCC devices can't be flashed. I tried every firmware version for the Xtreme 2 and the speaker rejected all of them.